### PR TITLE
Added support for Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require" : {
         "php" : ">=5.6.4",
-        "illuminate/support" : "5.4.*|5.5.*",
+        "illuminate/support" : "5.4.*|5.5.*|5.6.*",
         "forxer/gravatar" : "~2.0"
     },
     "autoload" : {


### PR DESCRIPTION
Simple change!

After upgrade gravatars still work on my project. I had to fork and pull from myself in order to be able to upgrade to Laravel 5.6.

Would be great if you look through and release newer version with Laravel 5.6 support :)